### PR TITLE
feat: vote 관련 기능 구현

### DIFF
--- a/src/main/java/com/ceos/vote/domain/leaderCandidate/entity/LeaderCandidate.java
+++ b/src/main/java/com/ceos/vote/domain/leaderCandidate/entity/LeaderCandidate.java
@@ -1,0 +1,32 @@
+package com.ceos.vote.domain.leaderCandidate.entity;
+
+import com.ceos.vote.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class LeaderCandidate extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "leader_candidate_id")
+    private Long id;
+
+    @Column(length = 32)
+    private String part;
+
+    @Column
+    private String name;
+
+    @Builder
+    public LeaderCandidate(String part, String name) {
+        this.part = part;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/leaderCandidate/entity/LeaderCandidate.java
+++ b/src/main/java/com/ceos/vote/domain/leaderCandidate/entity/LeaderCandidate.java
@@ -1,5 +1,6 @@
 package com.ceos.vote.domain.leaderCandidate.entity;
 
+import com.ceos.vote.domain.users.enumerate.Part;
 import com.ceos.vote.global.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -19,13 +20,13 @@ public class LeaderCandidate extends BaseEntity {
     private Long id;
 
     @Column(length = 32)
-    private String part;
+    private Part part;
 
     @Column
     private String name;
 
     @Builder
-    public LeaderCandidate(String part, String name) {
+    public LeaderCandidate(Part part, String name) {
         this.part = part;
         this.name = name;
     }

--- a/src/main/java/com/ceos/vote/domain/leaderCandidate/repository/LeaderCandidateRepository.java
+++ b/src/main/java/com/ceos/vote/domain/leaderCandidate/repository/LeaderCandidateRepository.java
@@ -1,0 +1,9 @@
+package com.ceos.vote.domain.leaderCandidate.repository;
+
+import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LeaderCandidateRepository extends JpaRepository<LeaderCandidate, Long> {
+}

--- a/src/main/java/com/ceos/vote/domain/leaderCandidate/repository/LeaderCandidateRepository.java
+++ b/src/main/java/com/ceos/vote/domain/leaderCandidate/repository/LeaderCandidateRepository.java
@@ -1,9 +1,13 @@
 package com.ceos.vote.domain.leaderCandidate.repository;
 
 import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
+import com.ceos.vote.domain.users.enumerate.Part;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface LeaderCandidateRepository extends JpaRepository<LeaderCandidate, Long> {
+    List<LeaderCandidate> findByPart(Part part);
 }

--- a/src/main/java/com/ceos/vote/domain/leaderCandidate/service/LeaderCandidateService.java
+++ b/src/main/java/com/ceos/vote/domain/leaderCandidate/service/LeaderCandidateService.java
@@ -1,0 +1,23 @@
+package com.ceos.vote.domain.leaderCandidate.service;
+
+import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
+import com.ceos.vote.domain.leaderCandidate.repository.LeaderCandidateRepository;
+import com.ceos.vote.global.exception.ApplicationException;
+import com.ceos.vote.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LeaderCandidateService {
+
+    private final LeaderCandidateRepository leaderCandidateRepository;
+
+    public LeaderCandidate findLeaderCandidateById(Long id) {
+        return leaderCandidateRepository.findById(id)
+                .orElseThrow(() -> new ApplicationException(ExceptionCode.NOT_FOUND_LEADER_CANDIDATE));
+    }
+
+}

--- a/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
@@ -1,15 +1,14 @@
 package com.ceos.vote.domain.leaderVote.controller;
 
 import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteCreateRequestDto;
+import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteUpdateRequestDto;
 import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteByUserResponseDto;
 import com.ceos.vote.domain.leaderVote.service.LeaderVoteService;
 import com.ceos.vote.global.common.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Leader Vote", description = "leader vote api")
 @RestController
@@ -18,14 +17,25 @@ import org.springframework.web.bind.annotation.RestController;
 public class LeaderVoteController {
     private final LeaderVoteService leaderVoteService;
 
+    @Operation(summary = "leader vote 생성")
+    @PostMapping
     public CommonResponse<Void> createLeaderVote(@RequestBody LeaderVoteCreateRequestDto requestDto){
         leaderVoteService.createLeaderVote(requestDto);
         return new CommonResponse<>("new leader vote를 생성하였습니다.");
     }
 
+    @Operation(summary = "user의 leader vote 조회")
+    @GetMapping("/{userId}")
     public CommonResponse<LeaderVoteByUserResponseDto> getLeaderVoteByUser(@PathVariable Long userId){
         final LeaderVoteByUserResponseDto leaderVoteByUser = leaderVoteService.getLeaderVoteByUser(userId);
         return new CommonResponse<>(leaderVoteByUser, "해당 user의 투표 결과 조회에 성공하였습니다.");
+    }
+
+    @Operation(summary = "user의 leader vote 수정")
+    @PutMapping("/{userId}")
+    public CommonResponse<Void> updateLeaderVote(@PathVariable Long userId, @RequestBody LeaderVoteUpdateRequestDto requestDto){
+        leaderVoteService.updateLeaderVoteByUser(userId, requestDto);
+        return new CommonResponse<>("leader vote 수정을 성공하였습니다.");
     }
 
 }

--- a/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
@@ -3,6 +3,7 @@ package com.ceos.vote.domain.leaderVote.controller;
 import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteCreateRequestDto;
 import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteUpdateRequestDto;
 import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteByUserResponseDto;
+import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteFinalResultResponseDto;
 import com.ceos.vote.domain.leaderVote.service.LeaderVoteService;
 import com.ceos.vote.global.common.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,6 +23,11 @@ public class LeaderVoteController {
     public CommonResponse<Void> createLeaderVote(@RequestBody LeaderVoteCreateRequestDto requestDto){
         leaderVoteService.createLeaderVote(requestDto);
         return new CommonResponse<>("new leader vote를 생성하였습니다.");
+    }
+
+    public CommonResponse<LeaderVoteFinalResultResponseDto> getLeaderVoteResult(){
+        final LeaderVoteFinalResultResponseDto resultResponseDto = leaderVoteService.getLeaderVoteFinalResult();
+        return new CommonResponse<>(resultResponseDto, "전체 투표 결과 조회를 성공하였습니다.");
     }
 
     @Operation(summary = "user의 leader vote 조회")

--- a/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
@@ -38,9 +38,9 @@ public class LeaderVoteController {
 
     @Operation(summary = "leader vote 전체 결과 조회")
     @GetMapping
-    public CommonResponse<LeaderVoteFinalResultResponseDto> getLeaderVoteResult(){
-        final LeaderVoteFinalResultResponseDto resultResponseDto = leaderVoteService.getLeaderVoteFinalResult();
-        return new CommonResponse<>(resultResponseDto, "전체 투표 결과 조회를 성공하였습니다.");
+    public CommonResponse<List<LeaderVoteFinalResultResponseDto>> getLeaderVoteResult(){
+        final List<LeaderVoteFinalResultResponseDto> results = leaderVoteService.getLeaderVoteFinalResult();
+        return new CommonResponse<>(results, "전체 투표 결과 조회를 성공하였습니다.");
     }
 
     @Operation(summary = "user의 leader vote 조회")

--- a/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
@@ -2,14 +2,18 @@ package com.ceos.vote.domain.leaderVote.controller;
 
 import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteCreateRequestDto;
 import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteUpdateRequestDto;
+import com.ceos.vote.domain.leaderVote.dto.response.LeaderCandidateResponseDto;
 import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteByUserResponseDto;
 import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteFinalResultResponseDto;
+import com.ceos.vote.domain.leaderVote.dto.response.PartCandidateResponseDto;
 import com.ceos.vote.domain.leaderVote.service.LeaderVoteService;
 import com.ceos.vote.global.common.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Leader Vote", description = "leader vote api")
 @RestController
@@ -18,6 +22,13 @@ import org.springframework.web.bind.annotation.*;
 public class LeaderVoteController {
     private final LeaderVoteService leaderVoteService;
 
+    @Operation(summary = "leader candidate 전체 조회")
+    @GetMapping("/candidate")
+    public CommonResponse<List<PartCandidateResponseDto>> getLeaderCandidates(){
+        final List<PartCandidateResponseDto> leaderCandidates = leaderVoteService.findLeaderCandidates();
+        return new CommonResponse<>(leaderCandidates, "전체 파트장 후보 조회를 성공하였습니다.");
+    }
+
     @Operation(summary = "leader vote 생성")
     @PostMapping
     public CommonResponse<Void> createLeaderVote(@RequestBody LeaderVoteCreateRequestDto requestDto){
@@ -25,6 +36,8 @@ public class LeaderVoteController {
         return new CommonResponse<>("new leader vote를 생성하였습니다.");
     }
 
+    @Operation(summary = "leader vote 전체 결과 조회")
+    @GetMapping
     public CommonResponse<LeaderVoteFinalResultResponseDto> getLeaderVoteResult(){
         final LeaderVoteFinalResultResponseDto resultResponseDto = leaderVoteService.getLeaderVoteFinalResult();
         return new CommonResponse<>(resultResponseDto, "전체 투표 결과 조회를 성공하였습니다.");

--- a/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
@@ -1,10 +1,12 @@
 package com.ceos.vote.domain.leaderVote.controller;
 
 import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteCreateRequestDto;
+import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteByUserResponseDto;
 import com.ceos.vote.domain.leaderVote.service.LeaderVoteService;
 import com.ceos.vote.global.common.response.CommonResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,6 +20,12 @@ public class LeaderVoteController {
 
     public CommonResponse<Void> createLeaderVote(@RequestBody LeaderVoteCreateRequestDto requestDto){
         leaderVoteService.createLeaderVote(requestDto);
-        return new CommonResponse<>("new leader vote created");
+        return new CommonResponse<>("new leader vote를 생성하였습니다.");
     }
+
+    public CommonResponse<LeaderVoteByUserResponseDto> getLeaderVoteByUser(@PathVariable Long userId){
+        final LeaderVoteByUserResponseDto leaderVoteByUser = leaderVoteService.getLeaderVoteByUser(userId);
+        return new CommonResponse<>(leaderVoteByUser, "해당 user의 투표 결과 조회에 성공하였습니다.");
+    }
+
 }

--- a/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
@@ -42,7 +42,7 @@ public class LeaderVoteController {
         return new CommonResponse<>(results, "전체 투표 결과 조회를 성공하였습니다.");
     }
 
-    @Operation(summary = "user의 leader vote 조회")
+    @Operation(summary = "user의 leader vote 결과 조회")
     @GetMapping("/{userId}")
     public CommonResponse<LeaderVoteByUserResponseDto> getLeaderVoteByUser(@PathVariable Long userId){
         final LeaderVoteByUserResponseDto leaderVoteByUser = leaderVoteService.getLeaderVoteByUser(userId);

--- a/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
@@ -1,0 +1,23 @@
+package com.ceos.vote.domain.leaderVote.controller;
+
+import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteCreateRequestDto;
+import com.ceos.vote.domain.leaderVote.service.LeaderVoteService;
+import com.ceos.vote.global.common.response.CommonResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Leader Vote", description = "leader vote api")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/leader")
+public class LeaderVoteController {
+    private final LeaderVoteService leaderVoteService;
+
+    public CommonResponse<Void> createLeaderVote(@RequestBody LeaderVoteCreateRequestDto requestDto){
+        leaderVoteService.createLeaderVote(requestDto);
+        return new CommonResponse<>("new leader vote created");
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/controller/LeaderVoteController.java
@@ -2,7 +2,6 @@ package com.ceos.vote.domain.leaderVote.controller;
 
 import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteCreateRequestDto;
 import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteUpdateRequestDto;
-import com.ceos.vote.domain.leaderVote.dto.response.LeaderCandidateResponseDto;
 import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteByUserResponseDto;
 import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteFinalResultResponseDto;
 import com.ceos.vote.domain.leaderVote.dto.response.PartCandidateResponseDto;

--- a/src/main/java/com/ceos/vote/domain/leaderVote/dto/request/LeaderVoteCreateRequestDto.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/dto/request/LeaderVoteCreateRequestDto.java
@@ -3,9 +3,12 @@ package com.ceos.vote.domain.leaderVote.dto.request;
 import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
 import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
 import com.ceos.vote.domain.users.entity.Users;
+import jakarta.validation.constraints.NotNull;
 
 public record LeaderVoteCreateRequestDto (
+        @NotNull
         Users user,
+        @NotNull
         LeaderCandidate leaderCandidate
 ){
     public LeaderVote toEntity(){

--- a/src/main/java/com/ceos/vote/domain/leaderVote/dto/request/LeaderVoteCreateRequestDto.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/dto/request/LeaderVoteCreateRequestDto.java
@@ -1,0 +1,17 @@
+package com.ceos.vote.domain.leaderVote.dto.request;
+
+import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
+import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
+import com.ceos.vote.domain.users.entity.Users;
+
+public record LeaderVoteCreateRequestDto (
+        Users user,
+        LeaderCandidate leaderCandidate
+){
+    public LeaderVote toEntity(){
+        return LeaderVote.builder()
+                .user(user)
+                .leaderCandidate(leaderCandidate)
+                .build();
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/leaderVote/dto/request/LeaderVoteCreateRequestDto.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/dto/request/LeaderVoteCreateRequestDto.java
@@ -3,9 +3,11 @@ package com.ceos.vote.domain.leaderVote.dto.request;
 import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
 import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
 import com.ceos.vote.domain.users.entity.Users;
+import jakarta.validation.constraints.NotNull;
 
 public record LeaderVoteCreateRequestDto (
         Long user_id,
+        @NotNull
         Long leader_candidate_id
 ){
     public LeaderVote toEntity(Users user, LeaderCandidate leaderCandidate) {

--- a/src/main/java/com/ceos/vote/domain/leaderVote/dto/request/LeaderVoteCreateRequestDto.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/dto/request/LeaderVoteCreateRequestDto.java
@@ -3,15 +3,12 @@ package com.ceos.vote.domain.leaderVote.dto.request;
 import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
 import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
 import com.ceos.vote.domain.users.entity.Users;
-import jakarta.validation.constraints.NotNull;
 
 public record LeaderVoteCreateRequestDto (
-        @NotNull
-        Users user,
-        @NotNull
-        LeaderCandidate leaderCandidate
+        Long user_id,
+        Long leader_candidate_id
 ){
-    public LeaderVote toEntity(){
+    public LeaderVote toEntity(Users user, LeaderCandidate leaderCandidate) {
         return LeaderVote.builder()
                 .user(user)
                 .leaderCandidate(leaderCandidate)

--- a/src/main/java/com/ceos/vote/domain/leaderVote/dto/request/LeaderVoteUpdateRequestDto.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/dto/request/LeaderVoteUpdateRequestDto.java
@@ -1,0 +1,10 @@
+package com.ceos.vote.domain.leaderVote.dto.request;
+
+import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
+import jakarta.validation.constraints.NotNull;
+
+public record LeaderVoteUpdateRequestDto(
+        @NotNull
+        Long leader_candidate_id
+){
+}

--- a/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/LeaderCandidateResponseDto.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/LeaderCandidateResponseDto.java
@@ -1,0 +1,15 @@
+package com.ceos.vote.domain.leaderVote.dto.response;
+
+import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
+
+public record LeaderCandidateResponseDto (
+        Long id,
+        String name
+){
+    public static LeaderCandidateResponseDto from(LeaderCandidate leaderCandidate) {
+        return new LeaderCandidateResponseDto(
+                leaderCandidate.getId(),
+                leaderCandidate.getName()
+        );
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/LeaderResultResponseDto.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/LeaderResultResponseDto.java
@@ -4,6 +4,10 @@ public record LeaderResultResponseDto (
         String leader_name,
         Long count
 ){
+    public Long getVoteCount() {
+        return count;
+    }
+
     public static LeaderResultResponseDto from(String leader_name, Long count){
         return new LeaderResultResponseDto(
                 leader_name,

--- a/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/LeaderResultResponseDto.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/LeaderResultResponseDto.java
@@ -1,0 +1,13 @@
+package com.ceos.vote.domain.leaderVote.dto.response;
+
+public record LeaderResultResponseDto (
+        String leader_name,
+        Long count
+){
+    public static LeaderResultResponseDto from(String leader_name, Long count){
+        return new LeaderResultResponseDto(
+                leader_name,
+                count
+        );
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/LeaderVoteByUserResponseDto.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/LeaderVoteByUserResponseDto.java
@@ -1,0 +1,17 @@
+package com.ceos.vote.domain.leaderVote.dto.response;
+
+import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
+import jakarta.validation.constraints.NotNull;
+
+public record LeaderVoteByUserResponseDto (
+        @NotNull
+        Boolean is_voting,
+        Long leader_Candidate_id
+){
+    public static LeaderVoteByUserResponseDto from(LeaderVote leaderVote, Boolean is_voting){
+        return new LeaderVoteByUserResponseDto(
+            is_voting,
+            leaderVote.getLeaderCandidate().getId()
+        );
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/LeaderVoteByUserResponseDto.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/LeaderVoteByUserResponseDto.java
@@ -10,8 +10,8 @@ public record LeaderVoteByUserResponseDto (
 ){
     public static LeaderVoteByUserResponseDto from(LeaderVote leaderVote, Boolean is_voting){
         return new LeaderVoteByUserResponseDto(
-            is_voting,
-            leaderVote.getLeaderCandidate().getId()
+                is_voting,
+                leaderVote != null ? leaderVote.getLeaderCandidate().getId() : null
         );
     }
 }

--- a/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/LeaderVoteFinalResultResponseDto.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/LeaderVoteFinalResultResponseDto.java
@@ -1,0 +1,15 @@
+package com.ceos.vote.domain.leaderVote.dto.response;
+
+import java.util.List;
+
+public record LeaderVoteFinalResultResponseDto (
+        Long total_count,
+        List<LeaderResultResponseDto> results
+){
+    public static LeaderVoteFinalResultResponseDto from(Long total_count, List<LeaderResultResponseDto> results){
+        return new LeaderVoteFinalResultResponseDto(
+                total_count,
+                results
+        );
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/LeaderVoteFinalResultResponseDto.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/LeaderVoteFinalResultResponseDto.java
@@ -1,13 +1,17 @@
 package com.ceos.vote.domain.leaderVote.dto.response;
 
+import com.ceos.vote.domain.users.enumerate.Part;
+
 import java.util.List;
 
 public record LeaderVoteFinalResultResponseDto (
+        String part,
         Long total_count,
         List<LeaderResultResponseDto> results
 ){
-    public static LeaderVoteFinalResultResponseDto from(Long total_count, List<LeaderResultResponseDto> results){
+    public static LeaderVoteFinalResultResponseDto from(Part part, Long total_count, List<LeaderResultResponseDto> results){
         return new LeaderVoteFinalResultResponseDto(
+                part.getDescription(), 
                 total_count,
                 results
         );

--- a/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/PartCandidateResponseDto.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/PartCandidateResponseDto.java
@@ -8,9 +8,9 @@ public record PartCandidateResponseDto (
         String part,
         List<LeaderCandidateResponseDto> leaderCandidates
 ){
-    public static PartCandidateResponseDto from(String part, List<LeaderCandidateResponseDto> leaderCandidates) {
+    public static PartCandidateResponseDto from(Part part, List<LeaderCandidateResponseDto> leaderCandidates) {
         return new PartCandidateResponseDto(
-                part,
+                part.getDescription(),
                 leaderCandidates
         );
     }

--- a/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/PartCandidateResponseDto.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/dto/response/PartCandidateResponseDto.java
@@ -1,0 +1,17 @@
+package com.ceos.vote.domain.leaderVote.dto.response;
+
+import com.ceos.vote.domain.users.enumerate.Part;
+
+import java.util.List;
+
+public record PartCandidateResponseDto (
+        String part,
+        List<LeaderCandidateResponseDto> leaderCandidates
+){
+    public static PartCandidateResponseDto from(String part, List<LeaderCandidateResponseDto> leaderCandidates) {
+        return new PartCandidateResponseDto(
+                part,
+                leaderCandidates
+        );
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/leaderVote/entity/LeaderVote.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/entity/LeaderVote.java
@@ -28,6 +28,10 @@ public class LeaderVote extends BaseEntity {
     @JoinColumn(name = "leader_candidate_id")
     private LeaderCandidate leaderCandidate;
 
+    public void setLeaderCandidate(LeaderCandidate leaderCandidate) {
+        this.leaderCandidate = leaderCandidate;
+    }
+
     @Builder
     public LeaderVote(Users user, LeaderCandidate leaderCandidate) {
         this.user = user;

--- a/src/main/java/com/ceos/vote/domain/leaderVote/entity/LeaderVote.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/entity/LeaderVote.java
@@ -1,0 +1,36 @@
+package com.ceos.vote.domain.leaderVote.entity;
+
+import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
+import com.ceos.vote.domain.users.entity.Users;
+import com.ceos.vote.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class LeaderVote extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "leader_candidate_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Users user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "leader_candidate_id")
+    private LeaderCandidate leaderCandidate;
+
+    @Builder
+    public LeaderVote(Users user, LeaderCandidate leaderCandidate) {
+        this.user = user;
+        this.leaderCandidate = leaderCandidate;
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/leaderVote/repository/LeaderVoteRepository.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/repository/LeaderVoteRepository.java
@@ -2,6 +2,7 @@ package com.ceos.vote.domain.leaderVote.repository;
 
 import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
 import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
+import com.ceos.vote.domain.users.enumerate.Part;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/ceos/vote/domain/leaderVote/repository/LeaderVoteRepository.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/repository/LeaderVoteRepository.java
@@ -4,6 +4,9 @@ import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface LeaderVoteRepository extends JpaRepository<LeaderVote, Long> {
+    Optional<LeaderVote> findByUserId(Long userId);
 }

--- a/src/main/java/com/ceos/vote/domain/leaderVote/repository/LeaderVoteRepository.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/repository/LeaderVoteRepository.java
@@ -1,0 +1,9 @@
+package com.ceos.vote.domain.leaderVote.repository;
+
+import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LeaderVoteRepository extends JpaRepository<LeaderVote, Long> {
+}

--- a/src/main/java/com/ceos/vote/domain/leaderVote/repository/LeaderVoteRepository.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/repository/LeaderVoteRepository.java
@@ -1,5 +1,6 @@
 package com.ceos.vote.domain.leaderVote.repository;
 
+import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
 import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,4 +10,6 @@ import java.util.Optional;
 @Repository
 public interface LeaderVoteRepository extends JpaRepository<LeaderVote, Long> {
     Optional<LeaderVote> findByUserId(Long userId);
+
+    Long countByLeaderCandidate(LeaderCandidate leaderCandidate);
 }

--- a/src/main/java/com/ceos/vote/domain/leaderVote/repository/LeaderVoteRepository.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/repository/LeaderVoteRepository.java
@@ -2,7 +2,6 @@ package com.ceos.vote.domain.leaderVote.repository;
 
 import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
 import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
-import com.ceos.vote.domain.users.enumerate.Part;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -107,9 +108,10 @@ public class LeaderVoteService {
         // 파트에 속한 모든 리더 후보 조회
         List<LeaderCandidate> leaderCandidates = leaderCandidateRepository.findByPart(part);
 
-        // 각 후보의 투표 결과 반환
+        // 각 후보의 투표 결과 반환 및 득표수 내림차순 정렬
         return leaderCandidates.stream()
                 .map(candidate -> LeaderResultResponseDto.from(candidate.getName(), leaderVoteRepository.countByLeaderCandidate(candidate)))
+                .sorted(Comparator.comparingLong(LeaderResultResponseDto::getVoteCount).reversed()) // 내림차순 정렬
                 .toList();
     }
 

--- a/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
@@ -1,8 +1,11 @@
 package com.ceos.vote.domain.leaderVote.service;
 
 import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteCreateRequestDto;
+import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteByUserResponseDto;
 import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
 import com.ceos.vote.domain.leaderVote.repository.LeaderVoteRepository;
+import com.ceos.vote.global.exception.ApplicationException;
+import com.ceos.vote.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +16,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class LeaderVoteService {
     private LeaderVoteRepository leaderVoteRepository;
 
+    public LeaderVote findLeaderVoteById(Long id) {
+        return leaderVoteRepository.findById(id)
+                .orElseThrow(() -> new ApplicationException(ExceptionCode.NOT_FOUND_LEADER_VOTE));
+    }
     /*
     leaderVote 생성
      */
@@ -20,5 +27,17 @@ public class LeaderVoteService {
     public void createLeaderVote(LeaderVoteCreateRequestDto requestDto) {
         final LeaderVote leaderVote = requestDto.toEntity();
         leaderVoteRepository.save(leaderVote);
+    }
+
+    /*
+    leaderVote 전체 결과 조회
+     */
+    public LeaderVoteByUserResponseDto getLeaderVoteByUser(final Long userId) {
+        try {
+            final LeaderVote leaderVote = findLeaderVoteById(userId);
+            return LeaderVoteByUserResponseDto.from(leaderVote, true);
+        } catch (Exception e) {
+            return LeaderVoteByUserResponseDto.from(null, false);
+        }
     }
 }

--- a/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
@@ -5,7 +5,9 @@ import com.ceos.vote.domain.leaderCandidate.repository.LeaderCandidateRepository
 import com.ceos.vote.domain.leaderCandidate.service.LeaderCandidateService;
 import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteCreateRequestDto;
 import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteUpdateRequestDto;
+import com.ceos.vote.domain.leaderVote.dto.response.LeaderResultResponseDto;
 import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteByUserResponseDto;
+import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteFinalResultResponseDto;
 import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
 import com.ceos.vote.domain.leaderVote.repository.LeaderVoteRepository;
 import com.ceos.vote.domain.users.entity.Users;
@@ -15,6 +17,9 @@ import com.ceos.vote.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -72,5 +77,31 @@ public class LeaderVoteService {
         leaderVote.setLeaderCandidate(leaderCandidate);
         leaderVoteRepository.save(leaderVote);
 
+    }
+
+    /*
+    user의 leaderVote 결과 조회
+     */
+    public LeaderResultResponseDto getLeaderResult(LeaderCandidate leaderCandidate) {
+        final String name = leaderCandidate.getName();
+        final Long count = leaderVoteRepository.countByLeaderCandidate(leaderCandidate);
+
+        return LeaderResultResponseDto.from(name, count);
+    }
+
+    /*
+    leaderVote 전체 결과 조회
+     */
+    public LeaderVoteFinalResultResponseDto getLeaderVoteFinalResult() {
+        List<LeaderCandidate> leaderCandidates = leaderCandidateRepository.findAll();
+        List<LeaderResultResponseDto> resultList = new ArrayList<>();
+
+        // 각 leader candidate의 결과를 LeaderResultResponseDto로 변환
+        leaderCandidates.forEach(leaderCandidate -> resultList.add(getLeaderResult(leaderCandidate)));
+
+        // 총 투표수 조회
+        final Long count = leaderVoteRepository.count();
+
+        return LeaderVoteFinalResultResponseDto.from(count, resultList);
     }
 }

--- a/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
@@ -5,12 +5,11 @@ import com.ceos.vote.domain.leaderCandidate.repository.LeaderCandidateRepository
 import com.ceos.vote.domain.leaderCandidate.service.LeaderCandidateService;
 import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteCreateRequestDto;
 import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteUpdateRequestDto;
-import com.ceos.vote.domain.leaderVote.dto.response.LeaderResultResponseDto;
-import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteByUserResponseDto;
-import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteFinalResultResponseDto;
+import com.ceos.vote.domain.leaderVote.dto.response.*;
 import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
 import com.ceos.vote.domain.leaderVote.repository.LeaderVoteRepository;
 import com.ceos.vote.domain.users.entity.Users;
+import com.ceos.vote.domain.users.enumerate.Part;
 import com.ceos.vote.domain.users.repository.UserRepository;
 import com.ceos.vote.global.exception.ApplicationException;
 import com.ceos.vote.global.exception.ExceptionCode;
@@ -19,7 +18,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.ceos.vote.domain.users.enumerate.Part.*;
+import static com.ceos.vote.domain.users.enumerate.Part.DESIGN;
 
 @Service
 @Transactional(readOnly = true)
@@ -39,6 +43,27 @@ public class LeaderVoteService {
     public Users findUserById(Long id) {
         return userRepository.findById(id)
                 .orElseThrow(() -> new ApplicationException(ExceptionCode.NOT_FOUND_EXCEPTION));
+    }
+
+    /*
+    파트별 leader candidate 조회
+     */
+    public List<LeaderCandidateResponseDto> findLeaderCandidatesByPart(Part part) {
+        List<LeaderCandidate> leaderCandidates = leaderCandidateRepository.findByPart(part);
+
+        return leaderCandidates.stream()
+                .map(LeaderCandidateResponseDto::from)
+                .toList();
+    }
+
+    /*
+    전체 leader candidate 조회
+     */
+    public List<PartCandidateResponseDto> findLeaderCandidates() {
+        // part별 leader candidate을 조회하여 PartCandidateResponseDto로 반환
+        return Arrays.stream(Part.values())
+                .map(part -> PartCandidateResponseDto.from(part.getDescription(), findLeaderCandidatesByPart(part)))
+                .collect(Collectors.toList());
     }
 
     /*

--- a/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
@@ -1,9 +1,15 @@
 package com.ceos.vote.domain.leaderVote.service;
 
+import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
+import com.ceos.vote.domain.leaderCandidate.repository.LeaderCandidateRepository;
+import com.ceos.vote.domain.leaderCandidate.service.LeaderCandidateService;
 import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteCreateRequestDto;
+import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteUpdateRequestDto;
 import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteByUserResponseDto;
 import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
 import com.ceos.vote.domain.leaderVote.repository.LeaderVoteRepository;
+import com.ceos.vote.domain.users.entity.Users;
+import com.ceos.vote.domain.users.repository.UserRepository;
 import com.ceos.vote.global.exception.ApplicationException;
 import com.ceos.vote.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
@@ -14,30 +20,53 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class LeaderVoteService {
+    private final UserRepository userRepository;
+    private final LeaderCandidateRepository leaderCandidateRepository;
+    private final LeaderCandidateService leaderCandidateService;
     private LeaderVoteRepository leaderVoteRepository;
 
-    public LeaderVote findLeaderVoteById(Long id) {
-        return leaderVoteRepository.findById(id)
+    public LeaderVote findLeaderVoteByUserId(Long id) {
+        return leaderVoteRepository.findByUserId(id)
                 .orElseThrow(() -> new ApplicationException(ExceptionCode.NOT_FOUND_LEADER_VOTE));
     }
+
     /*
     leaderVote 생성
      */
     @Transactional
     public void createLeaderVote(LeaderVoteCreateRequestDto requestDto) {
-        final LeaderVote leaderVote = requestDto.toEntity();
+        Users user = userRepository.findById(requestDto.user_id())
+                .orElseThrow(() -> new ApplicationException(ExceptionCode.NOT_FOUND_EXCEPTION));
+
+        LeaderCandidate leaderCandidate = leaderCandidateService.findLeaderCandidateById(requestDto.leader_candidate_id());
+
+        final LeaderVote leaderVote = requestDto.toEntity(user, leaderCandidate);
         leaderVoteRepository.save(leaderVote);
     }
 
     /*
-    leaderVote 전체 결과 조회
+    user의 leaderVote 결과 조회
      */
     public LeaderVoteByUserResponseDto getLeaderVoteByUser(final Long userId) {
         try {
-            final LeaderVote leaderVote = findLeaderVoteById(userId);
+            final LeaderVote leaderVote = findLeaderVoteByUserId(userId);
             return LeaderVoteByUserResponseDto.from(leaderVote, true);
         } catch (Exception e) {
             return LeaderVoteByUserResponseDto.from(null, false);
         }
+    }
+
+    /*
+    user의 leaderVote 수정
+     */
+    @Transactional
+    public void updateLeaderVoteByUser(final Long userId, final LeaderVoteUpdateRequestDto requestDto) {
+        LeaderVote leaderVote = findLeaderVoteByUserId(userId);
+
+        LeaderCandidate leaderCandidate = leaderCandidateService.findLeaderCandidateById(requestDto.leader_candidate_id());
+
+        leaderVote.setLeaderCandidate(leaderCandidate);
+        leaderVoteRepository.save(leaderVote);
+
     }
 }

--- a/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
@@ -30,14 +30,18 @@ public class LeaderVoteService {
                 .orElseThrow(() -> new ApplicationException(ExceptionCode.NOT_FOUND_LEADER_VOTE));
     }
 
+    // 추후 UserService에 통합 후 삭제
+    public Users findUserById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new ApplicationException(ExceptionCode.NOT_FOUND_EXCEPTION));
+    }
+
     /*
     leaderVote 생성
      */
     @Transactional
     public void createLeaderVote(LeaderVoteCreateRequestDto requestDto) {
-        Users user = userRepository.findById(requestDto.user_id())
-                .orElseThrow(() -> new ApplicationException(ExceptionCode.NOT_FOUND_EXCEPTION));
-
+        Users user = findUserById(requestDto.user_id());
         LeaderCandidate leaderCandidate = leaderCandidateService.findLeaderCandidateById(requestDto.leader_candidate_id());
 
         final LeaderVote leaderVote = requestDto.toEntity(user, leaderCandidate);

--- a/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
+++ b/src/main/java/com/ceos/vote/domain/leaderVote/service/LeaderVoteService.java
@@ -1,0 +1,24 @@
+package com.ceos.vote.domain.leaderVote.service;
+
+import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteCreateRequestDto;
+import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
+import com.ceos.vote.domain.leaderVote.repository.LeaderVoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LeaderVoteService {
+    private LeaderVoteRepository leaderVoteRepository;
+
+    /*
+    leaderVote 생성
+     */
+    @Transactional
+    public void createLeaderVote(LeaderVoteCreateRequestDto requestDto) {
+        final LeaderVote leaderVote = requestDto.toEntity();
+        leaderVoteRepository.save(leaderVote);
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/teamCandidate/entity/TeamCandidate.java
+++ b/src/main/java/com/ceos/vote/domain/teamCandidate/entity/TeamCandidate.java
@@ -1,0 +1,25 @@
+package com.ceos.vote.domain.teamCandidate.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TeamCandidate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "leader_candidate_id")
+    private Long id;
+
+    @Column
+    private String name;
+
+    @Builder
+    public TeamCandidate(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/teamCandidate/entity/TeamCandidate.java
+++ b/src/main/java/com/ceos/vote/domain/teamCandidate/entity/TeamCandidate.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class TeamCandidate {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "leader_candidate_id")
+    @Column(name = "team_candidate_id")
     private Long id;
 
     @Column

--- a/src/main/java/com/ceos/vote/domain/teamCandidate/repository/TeamCandidateRepository.java
+++ b/src/main/java/com/ceos/vote/domain/teamCandidate/repository/TeamCandidateRepository.java
@@ -1,0 +1,9 @@
+package com.ceos.vote.domain.teamCandidate.repository;
+
+import com.ceos.vote.domain.teamCandidate.entity.TeamCandidate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TeamCandidateRepository extends JpaRepository<TeamCandidate, Long> {
+}

--- a/src/main/java/com/ceos/vote/domain/teamCandidate/service/TeamCandidateService.java
+++ b/src/main/java/com/ceos/vote/domain/teamCandidate/service/TeamCandidateService.java
@@ -1,0 +1,24 @@
+package com.ceos.vote.domain.teamCandidate.service;
+
+import com.ceos.vote.domain.teamCandidate.entity.TeamCandidate;
+import com.ceos.vote.domain.teamCandidate.repository.TeamCandidateRepository;
+import com.ceos.vote.global.exception.ApplicationException;
+import com.ceos.vote.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TeamCandidateService {
+
+
+    private final TeamCandidateRepository teamCandidateRepository;
+
+    public TeamCandidate findTeamCandidateById(Long id) {
+        return teamCandidateRepository.findById(id)
+                .orElseThrow(() -> new ApplicationException(ExceptionCode.NOT_FOUND_TEAM_CANDIDATE));
+    }
+
+}

--- a/src/main/java/com/ceos/vote/domain/teamVote/controller/TeamVoteController.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/controller/TeamVoteController.java
@@ -1,5 +1,6 @@
 package com.ceos.vote.domain.teamVote.controller;
 
+import com.ceos.vote.domain.teamVote.dto.request.TeamVoteUpdateRequestDto;
 import com.ceos.vote.domain.teamVote.dto.response.TeamVoteByUserResponseDto;
 import com.ceos.vote.domain.teamVote.dto.request.TeamVoteCreateRequestDto;
 import com.ceos.vote.domain.teamVote.service.TeamVoteService;
@@ -38,5 +39,12 @@ public class TeamVoteController {
     public CommonResponse<TeamVoteByUserResponseDto> getTeamVoteByUser(@PathVariable Long userId){
         final TeamVoteByUserResponseDto teamVoteByUser = teamVoteService.getTeamVoteByUser(userId);
         return new CommonResponse<>(teamVoteByUser, "해당 user의 투표 결과 조회에 성공하였습니다.");
+    }
+
+    @Operation(summary = "user의 team vote 수정")
+    @PutMapping("/{userId}")
+    public CommonResponse<Void> updateTeamVote(@PathVariable Long userId, @RequestBody TeamVoteUpdateRequestDto requestDto){
+        teamVoteService.updateTeamVoteByUser(userId, requestDto);
+        return new CommonResponse<>("team vote 수정을 성공하였습니다.");
     }
 }

--- a/src/main/java/com/ceos/vote/domain/teamVote/controller/TeamVoteController.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/controller/TeamVoteController.java
@@ -1,16 +1,13 @@
 package com.ceos.vote.domain.teamVote.controller;
 
-import com.ceos.vote.domain.leaderVote.dto.response.PartCandidateResponseDto;
-import com.ceos.vote.domain.leaderVote.service.LeaderVoteService;
-import com.ceos.vote.domain.teamVote.dto.response.TeamCandidateResponseDto;
+import com.ceos.vote.domain.teamVote.dto.request.TeamVoteCreateRequestDto;
 import com.ceos.vote.domain.teamVote.service.TeamVoteService;
+import com.ceos.vote.domain.teamVote.dto.response.TeamCandidateResponseDto;
 import com.ceos.vote.global.common.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -26,5 +23,12 @@ public class TeamVoteController {
     public CommonResponse<List<TeamCandidateResponseDto>> getTeamCandidates(){
         final List<TeamCandidateResponseDto> teamCandidates = teamVoteService.findTeamCandidates();
         return new CommonResponse<>(teamCandidates, "전체 후보팀 조회를 성공하였습니다.");
+    }
+
+    @Operation(summary = "team vote 생성")
+    @PostMapping
+    public CommonResponse<Void> createTeamVote(@RequestBody TeamVoteCreateRequestDto requestDto){
+        teamVoteService.createTeamVote(requestDto);
+        return new CommonResponse<>("new team vote를 생성하였습니다.");
     }
 }

--- a/src/main/java/com/ceos/vote/domain/teamVote/controller/TeamVoteController.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/controller/TeamVoteController.java
@@ -1,5 +1,6 @@
 package com.ceos.vote.domain.teamVote.controller;
 
+import com.ceos.vote.domain.teamVote.dto.response.TeamVoteByUserResponseDto;
 import com.ceos.vote.domain.teamVote.dto.request.TeamVoteCreateRequestDto;
 import com.ceos.vote.domain.teamVote.service.TeamVoteService;
 import com.ceos.vote.domain.teamVote.dto.response.TeamCandidateResponseDto;
@@ -30,5 +31,12 @@ public class TeamVoteController {
     public CommonResponse<Void> createTeamVote(@RequestBody TeamVoteCreateRequestDto requestDto){
         teamVoteService.createTeamVote(requestDto);
         return new CommonResponse<>("new team vote를 생성하였습니다.");
+    }
+
+    @Operation(summary = "user의 team vote 결과 조회")
+    @GetMapping("/{userId}")
+    public CommonResponse<TeamVoteByUserResponseDto> getTeamVoteByUser(@PathVariable Long userId){
+        final TeamVoteByUserResponseDto teamVoteByUser = teamVoteService.getTeamVoteByUser(userId);
+        return new CommonResponse<>(teamVoteByUser, "해당 user의 투표 결과 조회에 성공하였습니다.");
     }
 }

--- a/src/main/java/com/ceos/vote/domain/teamVote/controller/TeamVoteController.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/controller/TeamVoteController.java
@@ -1,8 +1,10 @@
 package com.ceos.vote.domain.teamVote.controller;
 
+import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteFinalResultResponseDto;
 import com.ceos.vote.domain.teamVote.dto.request.TeamVoteUpdateRequestDto;
 import com.ceos.vote.domain.teamVote.dto.response.TeamVoteByUserResponseDto;
 import com.ceos.vote.domain.teamVote.dto.request.TeamVoteCreateRequestDto;
+import com.ceos.vote.domain.teamVote.dto.response.TeamVoteFinalResultResponseDto;
 import com.ceos.vote.domain.teamVote.service.TeamVoteService;
 import com.ceos.vote.domain.teamVote.dto.response.TeamCandidateResponseDto;
 import com.ceos.vote.global.common.response.CommonResponse;
@@ -32,6 +34,13 @@ public class TeamVoteController {
     public CommonResponse<Void> createTeamVote(@RequestBody TeamVoteCreateRequestDto requestDto){
         teamVoteService.createTeamVote(requestDto);
         return new CommonResponse<>("new team vote를 생성하였습니다.");
+    }
+
+    @Operation(summary = "team vote 전체 결과 조회")
+    @GetMapping
+    public CommonResponse<TeamVoteFinalResultResponseDto> getTeamVoteResult(){
+        final TeamVoteFinalResultResponseDto result = teamVoteService.getTeamVoteFinalResult();
+        return new CommonResponse<>(result, "전체 투표 결과 조회를 성공하였습니다.");
     }
 
     @Operation(summary = "user의 team vote 결과 조회")

--- a/src/main/java/com/ceos/vote/domain/teamVote/controller/TeamVoteController.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/controller/TeamVoteController.java
@@ -1,6 +1,5 @@
 package com.ceos.vote.domain.teamVote.controller;
 
-import com.ceos.vote.domain.leaderVote.dto.response.LeaderVoteFinalResultResponseDto;
 import com.ceos.vote.domain.teamVote.dto.request.TeamVoteUpdateRequestDto;
 import com.ceos.vote.domain.teamVote.dto.response.TeamVoteByUserResponseDto;
 import com.ceos.vote.domain.teamVote.dto.request.TeamVoteCreateRequestDto;

--- a/src/main/java/com/ceos/vote/domain/teamVote/controller/TeamVoteController.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/controller/TeamVoteController.java
@@ -1,0 +1,30 @@
+package com.ceos.vote.domain.teamVote.controller;
+
+import com.ceos.vote.domain.leaderVote.dto.response.PartCandidateResponseDto;
+import com.ceos.vote.domain.leaderVote.service.LeaderVoteService;
+import com.ceos.vote.domain.teamVote.dto.response.TeamCandidateResponseDto;
+import com.ceos.vote.domain.teamVote.service.TeamVoteService;
+import com.ceos.vote.global.common.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Team Vote", description = "team vote api")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/team")
+public class TeamVoteController {
+    private final TeamVoteService teamVoteService;
+
+    @Operation(summary = "team candidate 전체 조회")
+    @GetMapping("/candidate")
+    public CommonResponse<List<TeamCandidateResponseDto>> getTeamCandidates(){
+        final List<TeamCandidateResponseDto> teamCandidates = teamVoteService.findTeamCandidates();
+        return new CommonResponse<>(teamCandidates, "전체 후보팀 조회를 성공하였습니다.");
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/teamVote/dto/request/TeamVoteCreateRequestDto.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/dto/request/TeamVoteCreateRequestDto.java
@@ -1,0 +1,19 @@
+package com.ceos.vote.domain.teamVote.dto.request;
+
+import com.ceos.vote.domain.teamCandidate.entity.TeamCandidate;
+import com.ceos.vote.domain.teamVote.entity.TeamVote;
+import com.ceos.vote.domain.users.entity.Users;
+import jakarta.validation.constraints.NotNull;
+
+public record TeamVoteCreateRequestDto(
+        Long user_id,
+        @NotNull
+        Long team_candidate_id
+){
+    public TeamVote toEntity(Users user, TeamCandidate teamCandidate) {
+        return TeamVote.builder()
+                .user(user)
+                .teamCandidate(teamCandidate)
+                .build();
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/teamVote/dto/request/TeamVoteUpdateRequestDto.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/dto/request/TeamVoteUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package com.ceos.vote.domain.teamVote.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record TeamVoteUpdateRequestDto(
+        @NotNull
+        Long team_candidate_id
+){
+}

--- a/src/main/java/com/ceos/vote/domain/teamVote/dto/response/TeamCandidateResponseDto.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/dto/response/TeamCandidateResponseDto.java
@@ -1,0 +1,15 @@
+package com.ceos.vote.domain.teamVote.dto.response;
+
+import com.ceos.vote.domain.teamCandidate.entity.TeamCandidate;
+
+public record TeamCandidateResponseDto (
+        Long id,
+        String name
+){
+    public static TeamCandidateResponseDto from(TeamCandidate teamCandidate) {
+        return new TeamCandidateResponseDto(
+                teamCandidate.getId(),
+                teamCandidate.getName()
+        );
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/teamVote/dto/response/TeamResultResponseDto.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/dto/response/TeamResultResponseDto.java
@@ -1,0 +1,17 @@
+package com.ceos.vote.domain.teamVote.dto.response;
+
+public record TeamResultResponseDto(
+        String team_name,
+        Long count
+){
+    public Long getVoteCount() {
+        return count;
+    }
+
+    public static TeamResultResponseDto from(String team_name, Long count){
+        return new TeamResultResponseDto(
+                team_name,
+                count
+        );
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/teamVote/dto/response/TeamVoteByUserResponseDto.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/dto/response/TeamVoteByUserResponseDto.java
@@ -1,0 +1,17 @@
+package com.ceos.vote.domain.teamVote.dto.response;
+
+import com.ceos.vote.domain.teamVote.entity.TeamVote;
+import jakarta.validation.constraints.NotNull;
+
+public record TeamVoteByUserResponseDto(
+        @NotNull
+        Boolean is_voting,
+        Long team_Candidate_id
+){
+    public static TeamVoteByUserResponseDto from(TeamVote teamVote, Boolean is_voting){
+        return new TeamVoteByUserResponseDto(
+                is_voting,
+                teamVote != null ? teamVote.getTeamCandidate().getId() : null
+        );
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/teamVote/dto/response/TeamVoteFinalResultResponseDto.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/dto/response/TeamVoteFinalResultResponseDto.java
@@ -1,0 +1,15 @@
+package com.ceos.vote.domain.teamVote.dto.response;
+
+import java.util.List;
+
+public record TeamVoteFinalResultResponseDto(
+        Long total_count,
+        List<TeamResultResponseDto> results
+){
+    public static TeamVoteFinalResultResponseDto from(Long total_count, List<TeamResultResponseDto> results){
+        return new TeamVoteFinalResultResponseDto(
+                total_count,
+                results
+        );
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/teamVote/entity/TeamVote.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/entity/TeamVote.java
@@ -1,6 +1,6 @@
-package com.ceos.vote.domain.leaderVote.entity;
+package com.ceos.vote.domain.teamVote.entity;
 
-import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
+import com.ceos.vote.domain.teamCandidate.entity.TeamCandidate;
 import com.ceos.vote.domain.users.entity.Users;
 import com.ceos.vote.global.BaseEntity;
 import jakarta.persistence.*;
@@ -9,15 +9,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class LeaderVote extends BaseEntity {
+public class TeamVote extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "leader_vote_id")
+    @Column(name = "team_vote_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -25,16 +24,16 @@ public class LeaderVote extends BaseEntity {
     private Users user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "leader_candidate_id")
-    private LeaderCandidate leaderCandidate;
+    @JoinColumn(name = "team_candidate_id")
+    private TeamCandidate teamCandidate;
 
-    public void setLeaderCandidate(LeaderCandidate leaderCandidate) {
-        this.leaderCandidate = leaderCandidate;
+    public void setTeamCandidate(TeamCandidate teamCandidate) {
+        this.teamCandidate = teamCandidate;
     }
 
     @Builder
-    public LeaderVote(Users user, LeaderCandidate leaderCandidate) {
+    public TeamVote(Users user, TeamCandidate teamCandidate) {
         this.user = user;
-        this.leaderCandidate = leaderCandidate;
+        this.teamCandidate = teamCandidate;
     }
 }

--- a/src/main/java/com/ceos/vote/domain/teamVote/repository/TeamVoteRepository.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/repository/TeamVoteRepository.java
@@ -1,5 +1,6 @@
 package com.ceos.vote.domain.teamVote.repository;
 
+import com.ceos.vote.domain.teamCandidate.entity.TeamCandidate;
 import com.ceos.vote.domain.teamVote.entity.TeamVote;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,5 +10,5 @@ import java.util.Optional;
 @Repository
 public interface TeamVoteRepository extends JpaRepository<TeamVote, Long> {
     Optional<TeamVote> findByUserId(Long userId);
-
+    Long countByTeamCandidate(TeamCandidate teamCandidate);
 }

--- a/src/main/java/com/ceos/vote/domain/teamVote/repository/TeamVoteRepository.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/repository/TeamVoteRepository.java
@@ -4,6 +4,10 @@ import com.ceos.vote.domain.teamVote.entity.TeamVote;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface TeamVoteRepository extends JpaRepository<TeamVote, Long> {
+    Optional<TeamVote> findByUserId(Long userId);
+
 }

--- a/src/main/java/com/ceos/vote/domain/teamVote/repository/TeamVoteRepository.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/repository/TeamVoteRepository.java
@@ -1,0 +1,9 @@
+package com.ceos.vote.domain.teamVote.repository;
+
+import com.ceos.vote.domain.teamVote.entity.TeamVote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TeamVoteRepository extends JpaRepository<TeamVote, Long> {
+}

--- a/src/main/java/com/ceos/vote/domain/teamVote/service/TeamVoteService.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/service/TeamVoteService.java
@@ -1,16 +1,18 @@
 package com.ceos.vote.domain.teamVote.service;
 
+import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
 import com.ceos.vote.domain.leaderVote.service.LeaderVoteService;
 import com.ceos.vote.domain.teamCandidate.entity.TeamCandidate;
 import com.ceos.vote.domain.teamCandidate.service.TeamCandidateService;
 import com.ceos.vote.domain.teamVote.dto.request.TeamVoteCreateRequestDto;
+import com.ceos.vote.domain.teamVote.dto.response.TeamVoteByUserResponseDto;
 import com.ceos.vote.domain.teamVote.entity.TeamVote;
-import com.ceos.vote.domain.teamCandidate.entity.TeamCandidate;
 import com.ceos.vote.domain.teamCandidate.repository.TeamCandidateRepository;
 import com.ceos.vote.domain.teamVote.dto.response.TeamCandidateResponseDto;
 import com.ceos.vote.domain.teamVote.repository.TeamVoteRepository;
 import com.ceos.vote.domain.users.entity.Users;
-import com.ceos.vote.domain.users.enumerate.Part;
+import com.ceos.vote.global.exception.ApplicationException;
+import com.ceos.vote.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +27,11 @@ public class TeamVoteService {
     private final TeamCandidateRepository teamCandidateRepository;
     private final LeaderVoteService leaderVoteService;
     private final TeamCandidateService teamCandidateService;
+
+    public TeamVote findTeamVoteByUserId(Long id) {
+        return teamVoteRepository.findByUserId(id)
+                .orElseThrow(() -> new ApplicationException(ExceptionCode.NOT_FOUND_TEAM_VOTE));
+    }
 
     /*
     전체 team candidate 조회
@@ -47,5 +54,17 @@ public class TeamVoteService {
 
         final TeamVote teamVote = requestDto.toEntity(user, teamCandidate);
         teamVoteRepository.save(teamVote);
+    }
+
+    /*
+    user의 teamVote 결과 조회
+     */
+    public TeamVoteByUserResponseDto getTeamVoteByUser(final Long userId) {
+        try {
+            final TeamVote teamVote = findTeamVoteByUserId(userId);
+            return TeamVoteByUserResponseDto.from(teamVote, true);
+        } catch (Exception e) {
+            return TeamVoteByUserResponseDto.from(null, false);
+        }
     }
 }

--- a/src/main/java/com/ceos/vote/domain/teamVote/service/TeamVoteService.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/service/TeamVoteService.java
@@ -1,9 +1,15 @@
 package com.ceos.vote.domain.teamVote.service;
 
+import com.ceos.vote.domain.leaderVote.service.LeaderVoteService;
+import com.ceos.vote.domain.teamCandidate.entity.TeamCandidate;
+import com.ceos.vote.domain.teamCandidate.service.TeamCandidateService;
+import com.ceos.vote.domain.teamVote.dto.request.TeamVoteCreateRequestDto;
+import com.ceos.vote.domain.teamVote.entity.TeamVote;
 import com.ceos.vote.domain.teamCandidate.entity.TeamCandidate;
 import com.ceos.vote.domain.teamCandidate.repository.TeamCandidateRepository;
 import com.ceos.vote.domain.teamVote.dto.response.TeamCandidateResponseDto;
 import com.ceos.vote.domain.teamVote.repository.TeamVoteRepository;
+import com.ceos.vote.domain.users.entity.Users;
 import com.ceos.vote.domain.users.enumerate.Part;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +23,8 @@ import java.util.List;
 public class TeamVoteService {
     private final TeamVoteRepository teamVoteRepository;
     private final TeamCandidateRepository teamCandidateRepository;
+    private final LeaderVoteService leaderVoteService;
+    private final TeamCandidateService teamCandidateService;
 
     /*
     전체 team candidate 조회
@@ -27,5 +35,17 @@ public class TeamVoteService {
         return teamCandidates.stream()
                 .map(TeamCandidateResponseDto::from)
                 .toList();
+    }
+
+    /*
+    teamVote 생성
+     */
+    @Transactional
+    public void createTeamVote(TeamVoteCreateRequestDto requestDto) {
+        Users user = leaderVoteService.findUserById(requestDto.user_id());
+        TeamCandidate teamCandidate = teamCandidateService.findTeamCandidateById(requestDto.team_candidate_id());
+
+        final TeamVote teamVote = requestDto.toEntity(user, teamCandidate);
+        teamVoteRepository.save(teamVote);
     }
 }

--- a/src/main/java/com/ceos/vote/domain/teamVote/service/TeamVoteService.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/service/TeamVoteService.java
@@ -1,9 +1,5 @@
 package com.ceos.vote.domain.teamVote.service;
 
-import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
-import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteUpdateRequestDto;
-import com.ceos.vote.domain.leaderVote.dto.response.LeaderResultResponseDto;
-import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
 import com.ceos.vote.domain.leaderVote.service.LeaderVoteService;
 import com.ceos.vote.domain.teamCandidate.entity.TeamCandidate;
 import com.ceos.vote.domain.teamCandidate.service.TeamCandidateService;
@@ -17,7 +13,6 @@ import com.ceos.vote.domain.teamCandidate.repository.TeamCandidateRepository;
 import com.ceos.vote.domain.teamVote.dto.response.TeamCandidateResponseDto;
 import com.ceos.vote.domain.teamVote.repository.TeamVoteRepository;
 import com.ceos.vote.domain.users.entity.Users;
-import com.ceos.vote.domain.users.enumerate.Part;
 import com.ceos.vote.global.exception.ApplicationException;
 import com.ceos.vote.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/ceos/vote/domain/teamVote/service/TeamVoteService.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/service/TeamVoteService.java
@@ -1,10 +1,13 @@
 package com.ceos.vote.domain.teamVote.service;
 
+import com.ceos.vote.domain.leaderCandidate.entity.LeaderCandidate;
+import com.ceos.vote.domain.leaderVote.dto.request.LeaderVoteUpdateRequestDto;
 import com.ceos.vote.domain.leaderVote.entity.LeaderVote;
 import com.ceos.vote.domain.leaderVote.service.LeaderVoteService;
 import com.ceos.vote.domain.teamCandidate.entity.TeamCandidate;
 import com.ceos.vote.domain.teamCandidate.service.TeamCandidateService;
 import com.ceos.vote.domain.teamVote.dto.request.TeamVoteCreateRequestDto;
+import com.ceos.vote.domain.teamVote.dto.request.TeamVoteUpdateRequestDto;
 import com.ceos.vote.domain.teamVote.dto.response.TeamVoteByUserResponseDto;
 import com.ceos.vote.domain.teamVote.entity.TeamVote;
 import com.ceos.vote.domain.teamCandidate.repository.TeamCandidateRepository;
@@ -66,5 +69,19 @@ public class TeamVoteService {
         } catch (Exception e) {
             return TeamVoteByUserResponseDto.from(null, false);
         }
+    }
+
+    /*
+    user의 teamVote 수정
+     */
+    @Transactional
+    public void updateTeamVoteByUser(final Long userId, final TeamVoteUpdateRequestDto requestDto) {
+        TeamVote teamVote = findTeamVoteByUserId(userId);
+
+        TeamCandidate teamCandidate = teamCandidateService.findTeamCandidateById(requestDto.team_candidate_id());
+
+        teamVote.setTeamCandidate(teamCandidate);
+        teamVoteRepository.save(teamVote);
+
     }
 }

--- a/src/main/java/com/ceos/vote/domain/teamVote/service/TeamVoteService.java
+++ b/src/main/java/com/ceos/vote/domain/teamVote/service/TeamVoteService.java
@@ -1,0 +1,31 @@
+package com.ceos.vote.domain.teamVote.service;
+
+import com.ceos.vote.domain.teamCandidate.entity.TeamCandidate;
+import com.ceos.vote.domain.teamCandidate.repository.TeamCandidateRepository;
+import com.ceos.vote.domain.teamVote.dto.response.TeamCandidateResponseDto;
+import com.ceos.vote.domain.teamVote.repository.TeamVoteRepository;
+import com.ceos.vote.domain.users.enumerate.Part;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TeamVoteService {
+    private final TeamVoteRepository teamVoteRepository;
+    private final TeamCandidateRepository teamCandidateRepository;
+
+    /*
+    전체 team candidate 조회
+     */
+    public List<TeamCandidateResponseDto> findTeamCandidates() {
+        List<TeamCandidate> teamCandidates = teamCandidateRepository.findAll();
+
+        return teamCandidates.stream()
+                .map(TeamCandidateResponseDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/users/enumerate/Part.java
+++ b/src/main/java/com/ceos/vote/domain/users/enumerate/Part.java
@@ -1,0 +1,20 @@
+package com.ceos.vote.domain.users.enumerate;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public enum Part {
+
+    BE("BE"),
+    FE("FE"),
+    DESIGN("DESIGN"),
+    PLANNING("PLANNING");
+
+    private final String description;
+
+    Part(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/ceos/vote/domain/vote/entity/empty.java
+++ b/src/main/java/com/ceos/vote/domain/vote/entity/empty.java
@@ -1,4 +1,0 @@
-package com.ceos.vote.domain.vote.entity;
-
-public class empty {
-}

--- a/src/main/java/com/ceos/vote/domain/vote/repository/empty.java
+++ b/src/main/java/com/ceos/vote/domain/vote/repository/empty.java
@@ -1,4 +1,0 @@
-package com.ceos.vote.domain.vote.repository;
-
-public class empty {
-}

--- a/src/main/java/com/ceos/vote/global/exception/ExceptionCode.java
+++ b/src/main/java/com/ceos/vote/global/exception/ExceptionCode.java
@@ -19,11 +19,12 @@ public enum ExceptionCode {
     FORBIDDEN_EXCEPTION(HttpStatus.FORBIDDEN, 2005, "인가되지 않는 요청입니다."),
     ALREADY_EXIST_EXCEPTION(HttpStatus.BAD_REQUEST, 2006, "이미 존재하는 리소스입니다."),
     INVALID_SORT_EXCEPTION(HttpStatus.BAD_REQUEST, 2007, "올바르지 않은 정렬 값입니다."),
-    BAD_REQUEST_ERROR(HttpStatus.BAD_REQUEST, 2008, "잘못된 요청입니다.");
+    BAD_REQUEST_ERROR(HttpStatus.BAD_REQUEST, 2008, "잘못된 요청입니다."),
 
     // 3000:
 
-    // 4000:
+    // 4000: Leader Vote Error
+    NOT_FOUND_LEADER_VOTE(HttpStatus.NOT_FOUND, 4001, "해당 leader vote가 존재하지 않습니다.");
 
     // 5000:
 

--- a/src/main/java/com/ceos/vote/global/exception/ExceptionCode.java
+++ b/src/main/java/com/ceos/vote/global/exception/ExceptionCode.java
@@ -25,9 +25,11 @@ public enum ExceptionCode {
 
     // 4000: Leader Vote Error
     NOT_FOUND_LEADER_CANDIDATE(HttpStatus.NOT_FOUND, 4001, "해당 leader candidate가 존재하지 않습니다."),
-    NOT_FOUND_LEADER_VOTE(HttpStatus.NOT_FOUND, 4002, "해당 leader vote가 존재하지 않습니다.");
+    NOT_FOUND_LEADER_VOTE(HttpStatus.NOT_FOUND, 4002, "해당 leader vote가 존재하지 않습니다."),
 
-    // 5000:
+    // 5000: Team Vote Error
+    NOT_FOUND_TEAM_CANDIDATE(HttpStatus.NOT_FOUND, 4001, "해당 team candidate가 존재하지 않습니다."),
+    NOT_FOUND_TEAM_VOTE(HttpStatus.NOT_FOUND, 4002, "해당 team vote가 존재하지 않습니다.");
 
 
     // 6000:

--- a/src/main/java/com/ceos/vote/global/exception/ExceptionCode.java
+++ b/src/main/java/com/ceos/vote/global/exception/ExceptionCode.java
@@ -24,7 +24,8 @@ public enum ExceptionCode {
     // 3000:
 
     // 4000: Leader Vote Error
-    NOT_FOUND_LEADER_VOTE(HttpStatus.NOT_FOUND, 4001, "해당 leader vote가 존재하지 않습니다.");
+    NOT_FOUND_LEADER_CANDIDATE(HttpStatus.NOT_FOUND, 4001, "해당 leader candidate가 존재하지 않습니다."),
+    NOT_FOUND_LEADER_VOTE(HttpStatus.NOT_FOUND, 4002, "해당 leader vote가 존재하지 않습니다.");
 
     // 5000:
 


### PR DESCRIPTION
### 작업 내용
1. Part - enum type(BE, FE, DESIGN, PLANNING) 으로 변경
2. leader vote
    - 파트별 leader candidate 조회
    - leader vote 생성
    - leader vote by user 조회
    - leader vote by user 수정
    - leader vote 파트별 결과 조회
3. team vote
    - 전체 team candidate 조회
    - team vote 생성
    - team vote by user 조회
    - team vote by user 수정
    - team vote 전체 결과 조회
    
### TODO
- [x] user 관련 기능 구현 완료 후 `findUserById` 서비스 구현
- [ ] login한 user의 accessToken을 바탕으로 user를 추출하여 파라미터에 넣도록 리팩토링 (현재 userId로 구현되어있음)

### 기타
- 현재 user에 따라 '본인 파트만 투표가능하도록/본인팀 제외 투표 가능하도록' 에 대한 접근제한을 구현하지 않음. 프론트와 논의 필요