### PR TITLE
fix: 로그인 시 아이디/비밀번호 잘못 입력 시 에러 반환

### DIFF
--- a/src/main/java/com/ceos/vote/domain/auth/service/UserService.java
+++ b/src/main/java/com/ceos/vote/domain/auth/service/UserService.java
@@ -78,13 +78,25 @@ public class UserService {
 
     @Transactional
     public JwtToken signIn(String username, String password){
-        // 1. username + password 를 기반으로 Authentication 객체 생성
+
+        // username 존재여부 확인
+        Users users = userRepository.findByUsername(username)
+                .orElseThrow(() -> new ApplicationException(ExceptionCode.NOT_FOUND_USER));
+
+        // password 일치 여부 확인
+        if (!passwordEncoder.matches(password, users.getPassword())) {
+            throw new ApplicationException(ExceptionCode.INVALID_PASSWORD);
+        }
+
+        // username + password 를 기반으로 Authentication 객체 생성
         // 이때 authentication 은 인증 여부를 확인하는 authenticated 값이 false
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(username, password);
-        // 2. 실제 검증. authenticate() 메서드를 통해 요청된 Member 에 대한 검증 진행
+
+        // 실제 검증. authenticate() 메서드를 통해 요청된 Member 에 대한 검증 진행
         // authenticate 메서드가 실행될 때 CustomUserDetailsService 에서 만든 loadUserByUsername 메서드 실행
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-        // 3. 인증 정보를 기반으로 JWT 토큰 생성
+
+        // 인증 정보를 기반으로 JWT 토큰 생성
         JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
 
         return jwtToken;

--- a/src/main/java/com/ceos/vote/global/exception/ExceptionCode.java
+++ b/src/main/java/com/ceos/vote/global/exception/ExceptionCode.java
@@ -21,10 +21,11 @@ public enum ExceptionCode {
     INVALID_SORT_EXCEPTION(HttpStatus.BAD_REQUEST, 2007, "올바르지 않은 정렬 값입니다."),
     BAD_REQUEST_ERROR(HttpStatus.BAD_REQUEST, 2008, "잘못된 요청입니다."),
 
-    // 3000: USER
+    // 3000: USER/Auth
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, 3001, "해당 회원을 찾을 수 없습니다."),
     INVALID_USER_CREDENTIALS(HttpStatus.UNAUTHORIZED, 3002, "잘못된 사용자 인증 정보입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, 3003, "비밀번호를 찾을 수 없습니다."),
+    NOT_FOUND_USERNAME(HttpStatus.NOT_FOUND, 3004, "해당 아이디를 찾을 수 없습니다."),
 
     // 4000: Leader Vote Error
     NOT_FOUND_LEADER_CANDIDATE(HttpStatus.NOT_FOUND, 4001, "해당 leader candidate가 존재하지 않습니다."),


### PR DESCRIPTION
### 기능 변화
- 아이디를 잘못 입력하면 "회원을 찾을 수 없다"는 메세지를 출력합니다.
- 비밀번호를 잘못 입력하면 "비밀번호를 찾을 수 없다"는 메세지를 출력합니다.

